### PR TITLE
Remove canary logic

### DIFF
--- a/conf/prd.conf
+++ b/conf/prd.conf
@@ -4,12 +4,6 @@ kafka {
   hosts = "@@{prd.kafka_hosts}"
 }
 
-canary {
-  email {
-    address = "@@{prd.canary.email_address}"
-  }
-}
-
 profile.service {
   apiKey = "@@{prd.orchestration.profilesApiKey}"
   host = "@@{prd.profiles.host}"

--- a/conf/uat.conf
+++ b/conf/uat.conf
@@ -4,12 +4,6 @@ kafka {
   hosts = "@@{uat.kafka_hosts}"
 }
 
-canary {
-  email {
-    address = "@@{uat.canary.email_address}"
-  }
-}
-
 profile.service {
   apiKey = "@@{uat.orchestration.profilesApiKey}"
   host = "@@{uat.profiles.host}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     environment:
       ENV: LOCAL
       KAFKA_HOSTS: kafka:29092
-      CANARY_EMAIL_ADDRESS: some.email@ovoenergy.com
       PROFILE_SERVICE_API_KEY: someApiKey
       PROFILE_SERVICE_HOST: http://profile.service:1080
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -4,12 +4,6 @@ kafka {
   hosts = ${KAFKA_HOSTS} # comma-separated, e.g. "host1:9092,host2:9092"
 }
 
-canary {
-  email {
-    address = ${CANARY_EMAIL_ADDRESS}
-  }
-}
-
 profile.service {
   apiKey = ${PROFILE_SERVICE_API_KEY}
   host = ${PROFILE_SERVICE_HOST}

--- a/src/main/scala/com/ovoenergy/orchestration/Main.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/Main.scala
@@ -38,7 +38,6 @@ object Main extends App
 
   val orchestrator = Orchestrator(
     customerProfiler = CustomerProfiler(
-      canaryEmailAddress = config.getString("canary.email.address"),
       httpClient = HttpClient.apply,
       profileApiKey = config.getString("profile.service.apiKey"),
       profileHost = config.getString("profile.service.host")),

--- a/src/main/scala/com/ovoenergy/orchestration/processes/Orchestrator.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/processes/Orchestrator.scala
@@ -10,7 +10,9 @@ import scala.util.{Failure, Success, Try}
 
 object Orchestrator extends LoggingWithMDC {
 
-  def apply(customerProfiler: (String) => Try[CustomerProfile], channelSelector: (CustomerProfile) => Try[Channel], emailOrchestrator: (CustomerProfile, Triggered) => Future[_])
+  def apply(customerProfiler: (String, Boolean) => Try[CustomerProfile],
+            channelSelector: (CustomerProfile) => Try[Channel],
+            emailOrchestrator: (CustomerProfile, Triggered) => Future[_])
            (triggered: Triggered): Future[_] = {
 
     def determineOrchestrator(channel: Channel): Try[(CustomerProfile, Triggered) => Future[_]] = {
@@ -21,7 +23,7 @@ object Orchestrator extends LoggingWithMDC {
     }
 
     val orchestratorTry = for {
-      customerProfile <- customerProfiler(triggered.metadata.customerId)
+      customerProfile <- customerProfiler(triggered.metadata.customerId, triggered.metadata.canary)
       channel <- channelSelector(customerProfile)
       orchestrator <- determineOrchestrator(channel)
     } yield orchestrator(customerProfile, triggered)

--- a/src/main/scala/com/ovoenergy/orchestration/profile/CustomerProfiler.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/profile/CustomerProfiler.scala
@@ -1,53 +1,36 @@
 package com.ovoenergy.orchestration.profile
 
-import com.ovoenergy.orchestration.domain.customer.{CustomerProfile, CustomerProfileEmailAddresses, CustomerProfileName}
-import okhttp3.{Request, Response}
+import com.ovoenergy.orchestration.domain.customer.CustomerProfile
+import okhttp3.{HttpUrl, Request, Response}
 import com.ovoenergy.orchestration.http.JsonDecoding._
-
 import io.circe.generic.auto._
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Try}
 
 object CustomerProfiler {
 
-  def apply(canaryEmailAddress: String, httpClient: (Request) => Try[Response], profileApiKey: String, profileHost: String)
-           (customerId: String): Try[CustomerProfile] = {
+  def apply(httpClient: (Request) => Try[Response], profileApiKey: String, profileHost: String)
+           (customerId: String, canary: Boolean): Try[CustomerProfile] = {
 
-    val successfulStatusCodes = 200 to 299
-
-    def getCustomer: Try[CustomerProfile] = {
-      val request = new Request.Builder()
-        .url(s"$profileHost/api/customers/$customerId?apikey=$profileApiKey")
-        .get()
-        .build()
-
-      httpClient(request) match {
-        case Success(response) =>
-          val responseBody = response.body.string
-          if (successfulStatusCodes.contains(response.code)) {
-            decodeJson[CustomerProfile](responseBody)
-          } else {
-            Failure(new Exception(s"Error response (${response.code}) from profile service: $responseBody"))
-          }
-        case Failure(ex) => Failure(ex)
-      }
+    val url = {
+      val builder = HttpUrl.parse(s"$profileHost/api/customers/$customerId").newBuilder()
+        .addQueryParameter("apikey", profileApiKey)
+      if (canary) builder.addQueryParameter("canary", "true")
+      builder.build()
     }
 
-    customerId match {
-      case "canary" =>
-        Success(CustomerProfile(
-          name = CustomerProfileName(
-            title = Some("Master"),
-            firstName = "Tweety",
-            lastName = "Pie",
-            suffix = Some("Canary")
-          ),
-          emailAddresses = CustomerProfileEmailAddresses(
-            primary = Some(canaryEmailAddress),
-            secondary = None
-          )))
-      case _ =>
-        getCustomer
+    val request = new Request.Builder()
+      .url(url)
+      .get()
+      .build()
+
+    httpClient(request).flatMap { response =>
+      val responseBody = response.body.string
+      if (response.isSuccessful) {
+        decodeJson[CustomerProfile](responseBody)
+      } else {
+        Failure(new Exception(s"Error response (${response.code}) from profile service: $responseBody"))
+      }
     }
 
   }

--- a/src/test/scala/com/ovoenergy/orchestration/ServiceTestIT.scala
+++ b/src/test/scala/com/ovoenergy/orchestration/ServiceTestIT.scala
@@ -55,7 +55,7 @@ class ServiceTestIT extends FlatSpec
 
     val future = triggeredProducer.send(new ProducerRecord[String, Triggered](triggeredTopic, TestUtil.triggered))
     whenReady(future) {
-      case _ =>
+      _ =>
         val orchestratedEmails = emailOrchestratedConsumer.poll(30000).records(emailOrchestratedTopic).asScala.toList
         orchestratedEmails.size shouldBe 1
         orchestratedEmails.foreach(record => {
@@ -73,7 +73,7 @@ class ServiceTestIT extends FlatSpec
 
     val future = triggeredProducer.send(new ProducerRecord[String, Triggered](triggeredTopic, TestUtil.triggered))
     whenReady(future) {
-      case _ =>
+      _ =>
         val failures = commFailedConsumer.poll(30000).records(failedTopic).asScala.toList
         failures.size shouldBe 1
         failures.foreach(record => {
@@ -91,7 +91,7 @@ class ServiceTestIT extends FlatSpec
 
     val future = triggeredProducer.send(new ProducerRecord[String, Triggered](triggeredTopic, TestUtil.triggered))
     whenReady(future) {
-      case _ =>
+      _ =>
         val failures = commFailedConsumer.poll(30000).records(failedTopic).asScala.toList
         failures.size shouldBe 1
         failures.foreach(record => {

--- a/src/test/scala/com/ovoenergy/orchestration/processes/OrchestratorSpec.scala
+++ b/src/test/scala/com/ovoenergy/orchestration/processes/OrchestratorSpec.scala
@@ -27,7 +27,7 @@ class OrchestratorSpec extends FlatSpec
   }
 
   val customerProfile = CustomerProfile(CustomerProfileName(Some("Mr"), "John", "Smith", None), CustomerProfileEmailAddresses(Some("some.email@ovoenergy.com"), None))
-  def customerProfiler = (customerId: String) => {
+  def customerProfiler = (customerId: String, canary: Boolean) => {
     Success(customerProfile)
   }
 
@@ -51,7 +51,7 @@ class OrchestratorSpec extends FlatSpec
 
   it should "handle failed customer profiler" in {
     def selectEmailChannel = (customerProfile: CustomerProfile) => Success(Email)
-    def badCustomerProfiler = (customerId: String) => Failure(new Exception("whatever"))
+    def badCustomerProfiler = (customerId: String, canary: Boolean) => Failure(new Exception("whatever"))
     val future = Orchestrator(badCustomerProfiler, selectEmailChannel, emailOrchestrator)(TestUtil.triggered)
     whenReady(future.failed) { result =>
       invocationCount shouldBe 0
@@ -67,7 +67,5 @@ class OrchestratorSpec extends FlatSpec
       passedTriggered shouldBe TestUtil.triggered
     }
   }
-
-
 
 }


### PR DESCRIPTION
In the case of a canary event, the orchestrator should call the profiles service as normal, but pass the `canary=true` URL param.