### PR TITLE
Use the customerId as the key when sending Kafka events

### DIFF
--- a/src/main/scala/com/ovoenergy/orchestration/kafka/FailedProducer.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/kafka/FailedProducer.scala
@@ -19,7 +19,7 @@ object FailedProducer extends LoggingWithMDC {
 
     (failed: Failed) => {
       logWarn(failed.metadata.traceToken, s"Posting event to $topic - $failed")
-      producer.send(new ProducerRecord[String, Failed](topic, failed))
+      producer.send(new ProducerRecord[String, Failed](topic, failed.metadata.customerId, failed))
     }
   }
 

--- a/src/main/scala/com/ovoenergy/orchestration/kafka/OrchestratedEmailProducer.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/kafka/OrchestratedEmailProducer.scala
@@ -19,7 +19,7 @@ object OrchestratedEmailProducer extends LoggingWithMDC {
 
     (email: OrchestratedEmail) => {
       logInfo(email.metadata.traceToken, s"Posting event to $topic - $email")
-      producer.send(new ProducerRecord[String, OrchestratedEmail](topic, email))
+      producer.send(new ProducerRecord[String, OrchestratedEmail](topic, email.metadata.customerId, email))
     }
   }
 


### PR DESCRIPTION
This means that all events relating to a given customer will be in the same partition, and thus will be consumed in the order they were sent.

As suggested by @lehnerm.

If this seems reasonable, I'll do the same for all our other Kafka producers.