### PR TITLE
Upgrade comms-kafka-serialisation, circe, cats

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val circeVersion = "0.6.1"
+  val circeVersion = "0.7.0"
 
   def all() = Seq(
     "com.typesafe.akka"   %% "akka-http-core"            % "10.0.0",
@@ -10,11 +10,11 @@ object Dependencies {
     "com.typesafe.akka"   %% "akka-slf4j"                % "2.3.14",
     "net.cakesolutions"   %% "scala-kafka-client"        % "0.10.0.0",
     "com.ovoenergy"       %% "comms-kafka-messages"      % "0.0.29",
-    "com.ovoenergy"       %% "comms-kafka-serialisation" % "1.0",
+    "com.ovoenergy"       %% "comms-kafka-serialisation" % "2.0",
     "ch.qos.logback"       % "logback-classic"           % "1.1.7",
     "me.moocar"            % "logback-gelf"              % "0.2",
     "io.logz.logback"      % "logzio-logback-appender"   % "1.0.11",
-    "org.typelevel"       %% "cats-core"                 % "0.8.1",
+    "org.typelevel"       %% "cats-core"                 % "0.9.0",
     "com.squareup.okhttp3" % "okhttp"                    % "3.4.2",
     "io.circe"            %% "circe-core"                % circeVersion,
     "io.circe"            %% "circe-generic-extras"      % circeVersion,

--- a/src/main/scala/com/ovoenergy/orchestration/kafka/Serialisation.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/kafka/Serialisation.scala
@@ -2,6 +2,8 @@ package com.ovoenergy.orchestration.kafka
 
 import com.ovoenergy.comms.model.{Failed, OrchestratedEmail, Triggered}
 import com.ovoenergy.comms.serialisation.Serialisation._
+import com.ovoenergy.comms.serialisation.Decoders._
+import io.circe.generic.auto._
 
 object Serialisation {
 

--- a/src/test/scala/com/ovoenergy/orchestration/ServiceTestIT.scala
+++ b/src/test/scala/com/ovoenergy/orchestration/ServiceTestIT.scala
@@ -10,7 +10,9 @@ import com.ovoenergy.comms.model
 import com.ovoenergy.comms.model.ErrorCode.{InvalidProfile, OrchestrationError, ProfileRetrievalFailed}
 import com.ovoenergy.comms.model._
 import com.ovoenergy.comms.serialisation.Serialisation._
+import com.ovoenergy.comms.serialisation.Decoders._
 import com.ovoenergy.orchestration.util.TestUtil
+import io.circe.generic.auto._
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}


### PR DESCRIPTION
This means we are now using circe to deserialise JSON-encoded Avro messages