### PR TITLE
Consume TriggeredV2 events and produce OrchestratedEmailV2

### DIFF
--- a/conf/uat.conf
+++ b/conf/uat.conf
@@ -2,11 +2,6 @@ include "common.conf"
 
 kafka {
   hosts = "@@{uat.kafka_hosts}"
-  topics {
-    orchestrated {
-      email = "comms.orchestrated.email.v1"
-    }
-  }
 }
 
 profile.service {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     "com.typesafe.akka"   %% "akka-stream-kafka"         % "0.12",
     "com.typesafe.akka"   %% "akka-slf4j"                % "2.3.14",
     "net.cakesolutions"   %% "scala-kafka-client"        % "0.10.0.0",
-    "com.ovoenergy"       %% "comms-kafka-messages"      % "0.0.29",
+    "com.ovoenergy"       %% "comms-kafka-messages"      % "1.0",
     "com.ovoenergy"       %% "comms-kafka-serialisation" % "2.0",
     "ch.qos.logback"       % "logback-classic"           % "1.1.7",
     "me.moocar"            % "logback-gelf"              % "0.2",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.13")
+addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.17")
 
 resolvers += Resolver.bintrayIvyRepo("ovotech", "sbt-plugins")
 addSbtPlugin("com.ovoenergy" % "sbt-comms-packaging" % "0.0.2")

--- a/src/main/resources/common.conf
+++ b/src/main/resources/common.conf
@@ -2,9 +2,11 @@ kafka {
   group.id = "comms-orchestrator"
 
   topics {
-    triggered = "comms.triggered"
+    triggered.v1 = "comms.triggered"
+    triggered.v2 = "comms.triggered.v2"
+
     orchestrated {
-      email = "comms.orchestrated.email"
+      email.v2 = "comms.orchestrated.email.v2"
     }
     failed = "comms.failed"
   }

--- a/src/main/scala/com/ovoenergy/orchestration/kafka/OrchestratedEmailProducer.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/kafka/OrchestratedEmailProducer.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import cakesolutions.kafka.KafkaProducer
 import cakesolutions.kafka.KafkaProducer.Conf
-import com.ovoenergy.comms.model.OrchestratedEmail
+import com.ovoenergy.comms.model.{OrchestratedEmail, OrchestratedEmailV2}
 import com.ovoenergy.orchestration.logging.LoggingWithMDC
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer
@@ -14,12 +14,12 @@ import scala.concurrent.Future
 object OrchestratedEmailProducer extends LoggingWithMDC {
 
   def apply(hosts: String, topic: String)
-           (implicit actorSystem: ActorSystem, materializer: Materializer): OrchestratedEmail => Future[_] = {
-    val producer = KafkaProducer(Conf(new StringSerializer, Serialisation.orchestratedEmailSerializer, hosts))
+           (implicit actorSystem: ActorSystem, materializer: Materializer): OrchestratedEmailV2 => Future[_] = {
+    val producer = KafkaProducer(Conf(new StringSerializer, Serialisation.orchestratedEmailV2Serializer, hosts))
 
-    (email: OrchestratedEmail) => {
+    (email: OrchestratedEmailV2) => {
       logInfo(email.metadata.traceToken, s"Posting event to $topic - $email")
-      val future = producer.send(new ProducerRecord[String, OrchestratedEmail](topic, email.metadata.customerId, email))
+      val future = producer.send(new ProducerRecord[String, OrchestratedEmailV2](topic, email.metadata.customerId, email))
 
       import scala.concurrent.ExecutionContext.Implicits.global
       future.foreach {

--- a/src/main/scala/com/ovoenergy/orchestration/kafka/OrchestrationGraphV1.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/kafka/OrchestrationGraphV1.scala
@@ -7,7 +7,7 @@ import akka.kafka.{ConsumerSettings, Subscriptions}
 import akka.stream.scaladsl.{RunnableGraph, Sink}
 import akka.stream.{ActorAttributes, Materializer, Supervision}
 import com.ovoenergy.comms.model.ErrorCode.OrchestrationError
-import com.ovoenergy.comms.model.{ErrorCode, InternalMetadata, TriggeredV2}
+import com.ovoenergy.comms.model.{ErrorCode, InternalMetadata, Triggered, TriggeredV2}
 import com.ovoenergy.orchestration.logging.LoggingWithMDC
 import com.ovoenergy.orchestration.processes.Orchestrator.ErrorDetails
 import org.apache.kafka.common.serialization.{Deserializer, StringDeserializer}
@@ -15,12 +15,12 @@ import org.apache.kafka.common.serialization.{Deserializer, StringDeserializer}
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-case class OrchestrationGraphConfig(hosts: String, groupId: String, topic: String)
 
-object OrchestrationGraph extends LoggingWithMDC {
-  override def loggerName: String = "OrchestrationGraph"
+object OrchestrationGraphV1 extends LoggingWithMDC {
+  override def loggerName: String = "OrchestrationGraphV1"
 
-  def apply(consumerDeserializer: Deserializer[Option[TriggeredV2]],
+  def apply(consumerDeserializer: Deserializer[Option[Triggered]],
+            triggeredConverter: Triggered => TriggeredV2,
             orchestrationProcess: (TriggeredV2, InternalMetadata) => Either[ErrorDetails, Future[_]],
             failureProcess: (String, TriggeredV2, ErrorCode, InternalMetadata) => Future[_],
             config: OrchestrationGraphConfig,
@@ -47,12 +47,13 @@ object OrchestrationGraph extends LoggingWithMDC {
         val internalMetaData = InternalMetadata(traceTokenGenerator.apply)
         val result: Future[_] = msg.record.value match {
           case Some(triggered) =>
-            orchestrationProcess(triggered, internalMetaData) match {
-              case Left(err) => failureProcess(s"Orchestration failed: ${err.reason}", triggered, err.errorCode, internalMetaData)
+            val triggeredV2 = triggeredConverter(triggered)
+            orchestrationProcess(triggeredV2, internalMetaData) match {
+              case Left(err) => failureProcess(s"Orchestration failed: ${err.reason}", triggeredV2, err.errorCode, internalMetaData)
               case Right(future) => future.recoverWith {
                 case NonFatal(error) =>
-                  logWarn(triggered.metadata.traceToken, "Orchestration failed, raising failure", error)
-                  failureProcess(s"Orchestration failed: ${error.getMessage}", triggered, OrchestrationError, internalMetaData)
+                  logWarn(triggeredV2.metadata.traceToken, "Orchestration failed, raising failure", error)
+                  failureProcess(s"Orchestration failed: ${error.getMessage}", triggeredV2, OrchestrationError, internalMetaData)
               }
             }
           case None =>

--- a/src/main/scala/com/ovoenergy/orchestration/kafka/Serialisation.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/kafka/Serialisation.scala
@@ -1,6 +1,6 @@
 package com.ovoenergy.orchestration.kafka
 
-import com.ovoenergy.comms.model.{Failed, OrchestratedEmail, Triggered}
+import com.ovoenergy.comms.model._
 import com.ovoenergy.comms.serialisation.Serialisation._
 import com.ovoenergy.comms.serialisation.Decoders._
 import io.circe.generic.auto._
@@ -8,10 +8,9 @@ import io.circe.generic.auto._
 object Serialisation {
 
   val orchestratedEmailSerializer = avroSerializer[OrchestratedEmail]
-  val orchestratedEmailDeserializer = avroDeserializer[OrchestratedEmail]
-  val triggeredSerializer = avroSerializer[Triggered]
+  val orchestratedEmailV2Serializer = avroSerializer[OrchestratedEmailV2]
   val triggeredDeserializer = avroDeserializer[Triggered]
+  val triggeredV2Deserializer = avroDeserializer[TriggeredV2]
   val failedSerializer = avroSerializer[Failed]
-  val failedDeserializer = avroDeserializer[Failed]
 
 }

--- a/src/main/scala/com/ovoenergy/orchestration/processes/Orchestrator.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/processes/Orchestrator.scala
@@ -2,7 +2,7 @@ package com.ovoenergy.orchestration.processes
 
 import com.ovoenergy.comms.model.Channel.Email
 import com.ovoenergy.comms.model.ErrorCode.OrchestrationError
-import com.ovoenergy.comms.model.{Channel, ErrorCode, InternalMetadata, Triggered}
+import com.ovoenergy.comms.model._
 import com.ovoenergy.orchestration.domain.customer.CustomerProfile
 import com.ovoenergy.orchestration.logging.LoggingWithMDC
 
@@ -11,12 +11,12 @@ import scala.concurrent.Future
 object Orchestrator extends LoggingWithMDC {
   case class ErrorDetails(reason: String, errorCode: ErrorCode)
 
-  type Orchestrator = (CustomerProfile, Triggered, InternalMetadata) => Either[ErrorDetails, Future[_]]
+  type Orchestrator = (CustomerProfile, TriggeredV2, InternalMetadata) => Either[ErrorDetails, Future[_]]
 
   def apply(customerProfiler: (String, Boolean, String) => Either[ErrorDetails, CustomerProfile],
             channelSelector: (CustomerProfile) => Either[ErrorDetails, Channel],
             emailOrchestrator: Orchestrator)
-           (triggered: Triggered, internalMetadata: InternalMetadata): Either[ErrorDetails, Future[_]] = {
+           (triggered: TriggeredV2, internalMetadata: InternalMetadata): Either[ErrorDetails, Future[_]] = {
 
     def selectOrchestratorforChannel(channel: Channel): Either[ErrorDetails, Orchestrator] =
       channel match {

--- a/src/main/scala/com/ovoenergy/orchestration/processes/email/EmailOrchestration.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/processes/email/EmailOrchestration.scala
@@ -4,8 +4,8 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, Validated}
 import cats.{Apply, Semigroup}
 import com.ovoenergy.comms.model
-import com.ovoenergy.comms.model.ErrorCode.{InvalidProfile, OrchestrationError}
-import com.ovoenergy.comms.model.{InternalMetadata, Metadata, OrchestratedEmail, Triggered}
+import com.ovoenergy.comms.model.ErrorCode.InvalidProfile
+import com.ovoenergy.comms.model._
 import com.ovoenergy.orchestration.domain.customer.{CustomerProfile, CustomerProfileEmailAddresses}
 import com.ovoenergy.orchestration.processes.Orchestrator.ErrorDetails
 
@@ -28,8 +28,8 @@ object EmailOrchestration {
   }
   private type ValidationErrorsOr[A] = Validated[ValidationErrors, A]
 
-  def apply(orchestratedEmailProducer: (OrchestratedEmail) => Future[_])
-           (customerProfile: CustomerProfile, triggered: Triggered, internalMetadata: InternalMetadata): Either[ErrorDetails, Future[_]] = {
+  def apply(orchestratedEmailProducer: (OrchestratedEmailV2) => Future[_])
+           (customerProfile: CustomerProfile, triggered: TriggeredV2, internalMetadata: InternalMetadata): Either[ErrorDetails, Future[_]] = {
 
     val emailAddress: ValidationErrorsOr[String] = {
       customerProfile.emailAddresses match {
@@ -55,7 +55,7 @@ object EmailOrchestration {
     val resultOrValidationErrors: ValidationErrorsOr[Future[_]] =
       Apply[ValidationErrorsOr].map3(emailAddress, firstName, lastName) {
         case (validEmailAddress, validFirstName, validLastName) =>
-          val orchestratedEmail = OrchestratedEmail(
+          val orchestratedEmail = OrchestratedEmailV2(
             metadata = Metadata.fromSourceMetadata(
               source = "orchestration",
               sourceMetadata = triggered.metadata

--- a/src/main/scala/com/ovoenergy/orchestration/processes/failure/Failure.scala
+++ b/src/main/scala/com/ovoenergy/orchestration/processes/failure/Failure.scala
@@ -6,7 +6,7 @@ import scala.concurrent.Future
 
 object Failure {
 
-  def apply(failedProducer: (Failed) => Future[_])(reason: String, triggered: Triggered, errorCode: ErrorCode, internalMetadata: InternalMetadata): Future[_] = {
+  def apply(failedProducer: (Failed) => Future[_])(reason: String, triggered: TriggeredV2, errorCode: ErrorCode, internalMetadata: InternalMetadata): Future[_] = {
 
     val event = Failed(
       metadata = Metadata.fromSourceMetadata("orchestration", triggered.metadata),

--- a/src/test/scala/com/ovoenergy/orchestration/processes/FailureSpec.scala
+++ b/src/test/scala/com/ovoenergy/orchestration/processes/FailureSpec.scala
@@ -2,7 +2,7 @@ package com.ovoenergy.orchestration.processes
 
 import akka.Done
 import com.ovoenergy.comms.model.ErrorCode.OrchestrationError
-import com.ovoenergy.comms.model.{Failed, InternalMetadata, Triggered}
+import com.ovoenergy.comms.model.{Failed, InternalMetadata, TriggeredV2}
 import com.ovoenergy.orchestration.processes.failure.Failure
 import com.ovoenergy.orchestration.util.ArbGenerator
 import org.scalatest.concurrent.ScalaFutures
@@ -25,7 +25,7 @@ class FailureSpec extends FlatSpec
 
   it should "produced failed event" in {
     val internalMetaData = generate[InternalMetadata]
-    val triggered = generate[Triggered]
+    val triggered = generate[TriggeredV2]
     val future = Failure(producer)("Failure reason", triggered, OrchestrationError, internalMetaData)
     whenReady(future) { result =>
       providedFailed.reason shouldBe "Failure reason"

--- a/src/test/scala/com/ovoenergy/orchestration/processes/OrchestratorSpec.scala
+++ b/src/test/scala/com/ovoenergy/orchestration/processes/OrchestratorSpec.scala
@@ -7,11 +7,9 @@ import com.ovoenergy.comms.model._
 import com.ovoenergy.orchestration.domain.customer.CustomerProfile
 import com.ovoenergy.orchestration.processes.Orchestrator.ErrorDetails
 import com.ovoenergy.orchestration.util.ArbGenerator
-import org.scalacheck.Arbitrary
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{EitherValues, FlatSpec, Matchers, OneInstancePerTest}
 import org.scalacheck.Shapeless._
-import org.scalatest.{Failed => _, _}
 
 import scala.concurrent.Future
 
@@ -23,10 +21,10 @@ class OrchestratorSpec extends FlatSpec
   with ArbGenerator {
 
   var passedCustomerProfile: CustomerProfile = _
-  var passedTriggered: Triggered = _
+  var passedTriggered: TriggeredV2 = _
   var invocationCount: Int = 0
 
-  def emailOrchestrator = (customerProfile: CustomerProfile, triggered: Triggered, internalMetadata: InternalMetadata) => {
+  def emailOrchestrator = (customerProfile: CustomerProfile, triggered: TriggeredV2, internalMetadata: InternalMetadata) => {
     passedCustomerProfile = customerProfile
     passedTriggered = triggered
     invocationCount = invocationCount + 1
@@ -35,7 +33,7 @@ class OrchestratorSpec extends FlatSpec
 
 
   val customerProfile = generate[CustomerProfile]
-  val triggered       = generate[Triggered]
+  val triggered       = generate[TriggeredV2]
   val internalMetadata = generate[InternalMetadata]
 
   private def customerProfiler = (customerId: String, canary: Boolean, traceToken: String) => {

--- a/src/test/scala/com/ovoenergy/orchestration/processes/email/EmailOrchestrationSpec.scala
+++ b/src/test/scala/com/ovoenergy/orchestration/processes/email/EmailOrchestrationSpec.scala
@@ -22,8 +22,8 @@ class EmailOrchestrationSpec extends FlatSpec
   implicit val config = PatienceConfig()
 
   var producerInvocationCount = 0
-  var passedOrchestratedEmail: OrchestratedEmail = _
-  def producer = (orchestratedEmail: OrchestratedEmail) => {
+  var passedOrchestratedEmail: OrchestratedEmailV2 = _
+  def producer = (orchestratedEmail: OrchestratedEmailV2) => {
     producerInvocationCount = producerInvocationCount + 1
     passedOrchestratedEmail = orchestratedEmail
     Future.successful(Done)
@@ -31,7 +31,7 @@ class EmailOrchestrationSpec extends FlatSpec
 
 
   val customerProfile = generate[CustomerProfile]
-  val triggered       = generate[Triggered]
+  val triggered       = generate[TriggeredV2]
   val internalMetadata = generate[InternalMetadata]
 
   behavior of "EmailOrchestration"

--- a/src/test/scala/com/ovoenergy/orchestration/util/ArbGenerator.scala
+++ b/src/test/scala/com/ovoenergy/orchestration/util/ArbGenerator.scala
@@ -1,10 +1,15 @@
 package com.ovoenergy.orchestration.util
 
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Shapeless._
+import org.scalacheck.rng.Seed
+
+import scala.util.Random
 
 trait ArbGenerator {
 
-  def generate[A: Arbitrary] = implicitly[Arbitrary[A]].arbitrary.sample.get
+  def generate[A: Arbitrary] = implicitly[Arbitrary[A]].arbitrary
+    .apply(Gen.Parameters.default.withSize(Random.nextInt(5)), Seed.random())
+    .get
 
 }

--- a/src/test/scala/com/ovoenergy/orchestration/util/TestUtil.scala
+++ b/src/test/scala/com/ovoenergy/orchestration/util/TestUtil.scala
@@ -2,7 +2,8 @@ package com.ovoenergy.orchestration.util
 
 import java.util.UUID
 
-import com.ovoenergy.comms.model.{CommManifest, CommType, Metadata, Triggered}
+import com.ovoenergy.comms.model._
+import shapeless.Coproduct
 
 object TestUtil {
 
@@ -11,7 +12,8 @@ object TestUtil {
   val customerId = "GT-CUS-994332344"
   val friendlyDescription = "The customer did something cool and wants to know"
   val commManifest = CommManifest(CommType.Service, "Plain old email", "1.0")
-  val templateData = Map("someKey" -> "someValue")
+  val templateDataV1 = Map("someKey" -> "someValue")
+  val templateData = Map("someKey" -> TemplateData(Coproduct[TemplateData.TD]("someValue")))
 
   val metadata = Metadata(
     createdAt = createdAt,
@@ -26,7 +28,12 @@ object TestUtil {
     triggerSource = "test-trigger"
   )
 
-  val triggered = Triggered(
+  val triggeredV1 = Triggered(
+    metadata = metadata,
+    templateData = templateDataV1
+  )
+
+  val triggered = TriggeredV2(
     metadata = metadata,
     templateData = templateData
   )


### PR DESCRIPTION
Also keep consuming the existing `Triggered` messages, converting them to `TriggeredV2` before processing them.

Once we have migrated all producers to use `TriggeredV2`, we can remove this temporary workaround.

Note that this PR changes the Kafka topic that we write to. **DO NOT MERGE** until composer has been updated to consume from the new topic.